### PR TITLE
Fix: incorrect import paths for attention processors

### DIFF
--- a/models.py
+++ b/models.py
@@ -12,9 +12,9 @@ from transformers import (
 )
 
 from src.mask_ip_controller import *
-from src.ip_adapter.attention_processor import AttnProcessor2_0 as AttnProcessor
-from src.ip_adapter.attention_processor import IPAttnProcessor2_0 as IPAttnProcessor
-from src.ip_adapter.mask_attention_processor import IPAttnProcessor2_0WithIPMaskController
+from src.attention_processor import AttnProcessor2_0 as AttnProcessor
+from src.attention_processor import IPAttnProcessor2_0 as IPAttnProcessor
+from src.mask_attention_processor import IPAttnProcessor2_0WithIPMaskController
 
 def tokenize_captions(tokenizer, captions):
     inputs = tokenizer(


### PR DESCRIPTION
This PR fixes incorrect import statements in `models.py`.
Previously, the code attempted to import attention processor classes from `src.ip_adapter.*`, which caused `ModuleNotFoundError` when running the project.

**Changes:**
Updated imports to reference the correct top-level modules:
```
from src.attention_processor import AttnProcessor2_0 as AttnProcessor
from src.attention_processor import IPAttnProcessor2_0 as IPAttnProcessor
from src.mask_attention_processor import IPAttnProcessor2_0WithIPMaskController
```

**Reason**
The attention processor modules are located directly under `src/`, not under `src/ip_adapter/`. This fix ensures the project can be executed without import errors.

**Test**
Verified that the project runs after this change without raising `ModuleNotFoundError`.